### PR TITLE
Return unsubscribe function from addEventListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Manage multiple event handlers using few event listeners.
 ## Example
 
 ```js
-import { addEventListener, removeEventListener } from 'consolidated-events';
+import { addEventListener } from 'consolidated-events';
 
-const handle = addEventListener(
+const removeEventListener = addEventListener(
   window,
   'scroll',
   () => { console.log('scrolling') },

--- a/__tests__/TargetEventHandlers-test.js
+++ b/__tests__/TargetEventHandlers-test.js
@@ -8,15 +8,6 @@ class MockTarget {
 }
 
 describe('#add()', () => {
-  it('returns a handle', () => {
-    const target = new MockTarget();
-    const eventHandlers = new TargetEventHandlers(target);
-    const handle = eventHandlers.add('scroll', () => {});
-
-    expect(handle).not.toBe(null);
-    expect(handle).not.toBe(undefined);
-  });
-
   it('adds a single event listener to the target the first time', () => {
     const target = new MockTarget();
     const eventHandlers = new TargetEventHandlers(target);
@@ -70,59 +61,76 @@ describe('#add()', () => {
     expect(target.addEventListener)
       .toHaveBeenCalledWith('resize', jasmine.any(Function), undefined);
   });
-});
 
-describe('#delete()', () => {
-  it('deletes the event listener when the only handler is removed', () => {
+  it('returns an unsubscribe function', () => {
     const target = new MockTarget();
     const eventHandlers = new TargetEventHandlers(target);
-    const handle = eventHandlers.add('scroll', () => {});
-    eventHandlers.delete(handle);
+    const remove = eventHandlers.add('scroll', () => {});
+
+    expect(typeof remove).toBe('function');
+  });
+
+  it('unsubscribe deletes the event listener when the only handler is removed', () => {
+    const target = new MockTarget();
+    const eventHandlers = new TargetEventHandlers(target);
+    const remove = eventHandlers.add('scroll', () => {});
+    remove();
 
     expect(target.removeEventListener).toHaveBeenCalledTimes(1);
     expect(target.removeEventListener)
       .toHaveBeenCalledWith('scroll', jasmine.any(Function), undefined);
   });
 
-  it('does not delete the listener when removing an unknown handler', () => {
+  it('unsubscribe does not throw when called twice', () => {
     const target = new MockTarget();
     const eventHandlers = new TargetEventHandlers(target);
+    const remove = eventHandlers.add('scroll', () => {});
+    remove();
+
+    expect(remove).not.toThrow();
+  });
+
+  it('unsubscribe does not delete the event listener when there are more handlers left', () => {
+    const target = new MockTarget();
+    const eventHandlers = new TargetEventHandlers(target);
+    const remove = eventHandlers.add('scroll', () => {});
     eventHandlers.add('scroll', () => {});
-    eventHandlers.delete({ target: 'foo' });
+    remove();
 
     expect(target.removeEventListener).toHaveBeenCalledTimes(0);
   });
 
-  it('does not delete the event listener when there are more handlers left', () => {
+  it('unsubscribe called multiple times does not delete the event listener when there are more handlers left', () => {
     const target = new MockTarget();
     const eventHandlers = new TargetEventHandlers(target);
-    const handle = eventHandlers.add('scroll', () => {});
+    const remove = eventHandlers.add('scroll', () => {});
     eventHandlers.add('scroll', () => {});
-    eventHandlers.delete(handle);
+    remove();
+    remove();
 
     expect(target.removeEventListener).toHaveBeenCalledTimes(0);
   });
 
-  it('deletes the event listener when all handlers is removed', () => {
+  it('unsubscribe deletes the event listener when all handlers are removed', () => {
     const target = new MockTarget();
     const eventHandlers = new TargetEventHandlers(target);
-    const handle = eventHandlers.add('scroll', () => {});
-    const handle2 = eventHandlers.add('scroll', () => {});
-    eventHandlers.delete(handle);
-    eventHandlers.delete(handle2);
+    const remove = eventHandlers.add('scroll', () => {});
+    const remove2 = eventHandlers.add('scroll', () => {});
+    remove();
+    remove2();
 
     expect(target.removeEventListener).toHaveBeenCalledTimes(1);
     expect(target.removeEventListener)
       .toHaveBeenCalledWith('scroll', jasmine.any(Function), undefined);
   });
 
-  it('handles different options separately', () => {
+  it('unsubscribe handles different options separately', () => {
     const target = new MockTarget();
     const eventHandlers = new TargetEventHandlers(target);
-    const handle = eventHandlers.add('scroll', () => {});
-    const handle2 = eventHandlers.add('scroll', () => {}, { passive: true });
-    eventHandlers.delete(handle);
-    eventHandlers.delete(handle2);
+    const remove = eventHandlers.add('scroll', () => {});
+    const remove2 = eventHandlers.add('scroll', () => {}, { passive: true });
+    remove();
+    remove2();
 
     expect(target.removeEventListener).toHaveBeenCalledTimes(2);
     expect(target.removeEventListener)

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/first */
 import { addEventListener, removeEventListener, EVENT_HANDLERS_KEY } from '../src';
 import TargetEventHandlers from '../src/TargetEventHandlers';
 
@@ -25,25 +24,19 @@ describe('addEventListener()', () => {
       .toHaveBeenCalledWith('scroll', jasmine.any(Function), true);
   });
 
-  it('returns a handle', () => {
+  it('returns an unsubscribe function', () => {
     const target = new MockTarget();
-    const handle = addEventListener(target, 'scroll', () => {}, { capture: true });
+    const remove = addEventListener(target, 'scroll', () => {}, { capture: true });
 
-    expect(handle).not.toBe(null);
-    expect(handle).not.toBe(undefined);
+    expect(typeof remove).toBe('function');
   });
 });
 
 describe('removeEventListener()', () => {
-  it('does not throw when target is undefined', () => {
-    const handle = { target: undefined };
-    expect(() => removeEventListener(handle)).not.toThrow();
-  });
-
   it('removes event listeners that were previously registered', () => {
     const target = new MockTarget();
-    const handle = addEventListener(target, 'scroll', () => {});
-    removeEventListener(handle);
+    const unsubscribe = addEventListener(target, 'scroll', () => {});
+    removeEventListener(unsubscribe);
 
     expect(target.removeEventListener)
       .toHaveBeenCalledWith('scroll', jasmine.any(Function), undefined);
@@ -52,16 +45,16 @@ describe('removeEventListener()', () => {
   it('ignores event listeners it does not know about', () => {
     const target = new MockTarget();
     addEventListener(target, 'scroll', () => {});
-    removeEventListener({ target, eventName: 'scroll', index: 'foo' });
-    removeEventListener({ target, eventName: 'resize', index: 'foo' });
+    removeEventListener(() => {});
+    removeEventListener(() => {});
 
     expect(target.removeEventListener).toHaveBeenCalledTimes(0);
   });
 
   it('normalizes event options', () => {
     const target = new MockTarget();
-    const handle = addEventListener(target, 'scroll', () => {}, { capture: true });
-    removeEventListener(handle);
+    const unsubscribe = addEventListener(target, 'scroll', () => {}, { capture: true });
+    removeEventListener(unsubscribe);
 
     expect(target.removeEventListener)
       .toHaveBeenCalledWith('scroll', jasmine.any(Function), true);

--- a/src/index.js
+++ b/src/index.js
@@ -13,15 +13,7 @@ export function addEventListener(target, eventName, listener, options) {
   return target[EVENT_HANDLERS_KEY].add(eventName, listener, normalizedEventOptions);
 }
 
-export function removeEventListener(eventHandle) {
-  const { target } = eventHandle;
-
-  // There can be a race condition where the target may no longer exist when
-  // this function is called, e.g. when a React component is unmounting.
-  // Guarding against this prevents the following error:
-  //
-  //   Cannot read property 'removeEventListener' of undefined
-  if (target) {
-    target[EVENT_HANDLERS_KEY].delete(eventHandle);
-  }
+// Deprecated
+export function removeEventListener(unsubscribeFn) {
+  unsubscribeFn();
 }


### PR DESCRIPTION
Instead of returning a handle, which you need to pass to
`removeEventListener`, I think it might be nicer to return a function
that you can simply call.

So instead of this:

```js
import { addEventListener, removeEventListener } from 'consolidated-events';

const handle = addEventListener(...);
...
removeEventListener(handle);
```

The API would be this:

```js
import { addEventListener } from 'consolidated-events';

const unsubscribe = addEventListener(...);
...
unsubscribe();
```


I decided to keep the `removeEventListener` function around to keep this
change semver minor, but since it really isn't needed anymore, I am
marking it as deprecated and removing it from the documentation to
encourage people to use the new API.

Closes #3 

cc @trotzig @jmeas @ljharb 