### PR TITLE
Prevent event handlers from mutating current iteration

### DIFF
--- a/__tests__/TargetEventHandlers-test.js
+++ b/__tests__/TargetEventHandlers-test.js
@@ -157,6 +157,27 @@ describe('#handleEvent', () => {
     });
   });
 
+  it('calls each handler even when one is removed when called', () => {
+    const target = new MockTarget();
+    const eventHandlers = new TargetEventHandlers(target);
+
+    let remove;
+    const firstHandler = jest.fn(() => remove());
+    remove = eventHandlers.add('scroll', firstHandler);
+
+    const secondHandler = jest.fn();
+    eventHandlers.add('scroll', secondHandler);
+
+    const event = {};
+    eventHandlers.handleEvent('scroll', undefined, event);
+
+    expect(firstHandler).toHaveBeenCalledTimes(1);
+    expect(firstHandler).toHaveBeenCalledWith(event);
+
+    expect(secondHandler).toHaveBeenCalledTimes(1);
+    expect(secondHandler).toHaveBeenCalledWith(event);
+  });
+
   it('calls each handler with options', () => {
     const target = new MockTarget();
     const eventHandlers = new TargetEventHandlers(target);

--- a/src/TargetEventHandlers.js
+++ b/src/TargetEventHandlers.js
@@ -1,5 +1,12 @@
 import eventOptionsKey from './eventOptionsKey';
 
+function ensureCanMutateNextEventHandlers(eventHandlers) {
+  if (eventHandlers.handlers === eventHandlers.nextHandlers) {
+    // eslint-disable-next-line no-param-reassign
+    eventHandlers.nextHandlers = eventHandlers.handlers.slice();
+  }
+}
+
 export default class TargetEventHandlers {
   constructor(target) {
     this.target = target;
@@ -20,13 +27,6 @@ export default class TargetEventHandlers {
     return this.events[key];
   }
 
-  ensureCanMutateNextEventHandlers(eventName, options) {
-    const eventHandlers = this.getEventHandlers(eventName, options);
-    if (eventHandlers.handlers === eventHandlers.nextHandlers) {
-      eventHandlers.nextHandlers = eventHandlers.handlers.slice();
-    }
-  }
-
   handleEvent(eventName, options, event) {
     const eventHandlers = this.getEventHandlers(eventName, options);
     eventHandlers.handlers = eventHandlers.nextHandlers;
@@ -45,7 +45,7 @@ export default class TargetEventHandlers {
     // options has already been normalized at this point.
     const eventHandlers = this.getEventHandlers(eventName, options);
 
-    this.ensureCanMutateNextEventHandlers(eventName, options);
+    ensureCanMutateNextEventHandlers(eventHandlers);
 
     if (eventHandlers.nextHandlers.length === 0) {
       eventHandlers.handleEvent = this.handleEvent.bind(this, eventName, options);
@@ -67,7 +67,7 @@ export default class TargetEventHandlers {
 
       isSubscribed = false;
 
-      this.ensureCanMutateNextEventHandlers(eventName, options);
+      ensureCanMutateNextEventHandlers(eventHandlers);
       const index = eventHandlers.nextHandlers.indexOf(listener);
       eventHandlers.nextHandlers.splice(index, 1);
 

--- a/src/TargetEventHandlers.js
+++ b/src/TargetEventHandlers.js
@@ -14,14 +14,23 @@ export default class TargetEventHandlers {
         handlers: [],
         handleEvent: undefined,
       };
+      this.events[key].nextHandlers = this.events[key].handlers;
     }
 
     return this.events[key];
   }
 
+  ensureCanMutateNextEventHandlers(eventName, options) {
+    const eventHandlers = this.getEventHandlers(eventName, options);
+    if (eventHandlers.handlers === eventHandlers.nextHandlers) {
+      eventHandlers.nextHandlers = eventHandlers.handlers.slice();
+    }
+  }
+
   handleEvent(eventName, options, event) {
-    const { handlers } = this.getEventHandlers(eventName, options);
-    handlers.forEach((handler) => {
+    const eventHandlers = this.getEventHandlers(eventName, options);
+    eventHandlers.handlers = eventHandlers.nextHandlers;
+    eventHandlers.handlers.forEach((handler) => {
       if (handler) {
         // We need to check for presence here because a handler function may
         // cause later handlers to get removed. This can happen if you for
@@ -36,7 +45,9 @@ export default class TargetEventHandlers {
     // options has already been normalized at this point.
     const eventHandlers = this.getEventHandlers(eventName, options);
 
-    if (eventHandlers.handlers.length === 0) {
+    this.ensureCanMutateNextEventHandlers(eventName, options);
+
+    if (eventHandlers.nextHandlers.length === 0) {
       eventHandlers.handleEvent = this.handleEvent.bind(this, eventName, options);
 
       this.target.addEventListener(
@@ -46,7 +57,7 @@ export default class TargetEventHandlers {
       );
     }
 
-    eventHandlers.handlers.push(listener);
+    eventHandlers.nextHandlers.push(listener);
 
     let isSubscribed = true;
     const unsubscribe = () => {
@@ -56,10 +67,11 @@ export default class TargetEventHandlers {
 
       isSubscribed = false;
 
-      const index = eventHandlers.handlers.indexOf(listener);
-      eventHandlers.handlers.splice(index, 1);
+      this.ensureCanMutateNextEventHandlers(eventName, options);
+      const index = eventHandlers.nextHandlers.indexOf(listener);
+      eventHandlers.nextHandlers.splice(index, 1);
 
-      if (eventHandlers.handlers.length === 0) {
+      if (eventHandlers.nextHandlers.length === 0) {
         // All event handlers have been removed, so we want to remove the event
         // listener from the target node.
 


### PR DESCRIPTION
Removing an event handler during an active handleEvent iteration can
causes other handlers to be skipped:

```js
const removeClickListener = addEventListener(document, 'click', handler);
const removeAnotherClickListener = addEventListener(document, 'click', anotherHandler);

function handler() {
  removeClickListener(); // remove myself
}

function anotherHandler() {
  // I am never called!
}
```

This could be solved by making a copy of the handler array before
iterating through it, so any removed handlers will not affect the
current iteration.

```js
handlers.slice().forEach((handler) => {
  ...
})
```

However, I'd like to avoid unnecessarily allocating new Arrays to keep
performance high, so I've decided to use an approach that only copies
the array during the functions that modify the list of handlers.

Fixes #5
Closes #6

@aarongloege @ljharb 
