### PR TITLE
Use rollup to generate one CommonJS module with more efficent code & ship ESM version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.1",
   "description": "Manage multiple event handlers using few event listeners",
   "main": "lib/index.js",
+  "module": "lib/index.esm.js",
   "scripts": {
     "build": "npm run clean && npm run build:js",
     "build:js": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "npm run clean && npm run build:js",
-    "build:js": "babel src/ -d lib/",
+    "build:js": "rollup -c",
     "check-changelog": "expr $(git status --porcelain 2>/dev/null| grep \"^\\s*M.*CHANGELOG.md\" | wc -l) >/dev/null || (echo 'Please edit CHANGELOG.md' && exit 1)",
     "check-only-changelog-changed": "(expr $(git status --porcelain 2>/dev/null| grep -v \"CHANGELOG.md\" | wc -l) >/dev/null && echo 'Only CHANGELOG.md may have uncommitted changes' && exit 1) || exit 0",
     "clean": "rimraf lib",
@@ -36,7 +36,6 @@
   },
   "homepage": "https://github.com/lencioni/consolidated-events#readme",
   "devDependencies": {
-    "babel-cli": "^6.22.2",
     "babel-core": "^6.22.1",
     "babel-jest": "^20.0.0",
     "babel-preset-airbnb": "^2.2.3",
@@ -47,6 +46,8 @@
     "jest": "^20.0.0",
     "jest-wrap": "^1.0.0",
     "rimraf": "^2.6.1",
+    "rollup": "^0.60.7",
+    "rollup-plugin-babel": "^3.0.4",
     "safe-publish-latest": "^1.1.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,16 @@
+import babel from 'rollup-plugin-babel';
+import pkg from './package.json';
+
+export default {
+  input: 'src/index.js',
+  output: {
+    file: pkg.main,
+    format: 'cjs',
+  },
+  plugins: [
+    babel({
+      babelrc: false,
+      presets: [['airbnb', { modules: false }]],
+    }),
+  ],
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,10 +3,16 @@ import pkg from './package.json';
 
 export default {
   input: 'src/index.js',
-  output: {
-    file: pkg.main,
-    format: 'cjs',
-  },
+  output: [
+    {
+      file: pkg.main,
+      format: 'cjs',
+    },
+    {
+      file: pkg.module,
+      format: 'esm',
+    },
+  ],
   plugins: [
     babel({
       babelrc: false,


### PR DESCRIPTION
This reduces bundle size and startup when working with, for example, webpack, where every module is loaded individually. It also removes all the `_interopRequireDefault` functions.

I've also added an ESM version of the module to the package. Since consolidated-events uses named export, this is compatible with bundlers like Webpack even when the requiring app/library uses CommonJS.