### PR TITLE
Remove export added for testing

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -1,4 +1,4 @@
-import { addEventListener, removeEventListener, EVENT_HANDLERS_KEY } from '../src';
+import { addEventListener, removeEventListener } from '../src';
 import TargetEventHandlers from '../src/TargetEventHandlers';
 
 class MockTarget {
@@ -7,6 +7,8 @@ class MockTarget {
     this.removeEventListener = jest.fn();
   }
 }
+
+const EVENT_HANDLERS_KEY = '__consolidated_events_handlers__';
 
 describe('addEventListener()', () => {
   it('initializes an instance of TargetEventHandlers on new targets', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,7 @@
 import normalizeEventOptions from './normalizeEventOptions';
 import TargetEventHandlers from './TargetEventHandlers';
 
-// Export to make testing possible.
-export const EVENT_HANDLERS_KEY = '__consolidated_events_handlers__';
+const EVENT_HANDLERS_KEY = '__consolidated_events_handlers__';
 
 export function addEventListener(target, eventName, listener, options) {
   if (!target[EVENT_HANDLERS_KEY]) {


### PR DESCRIPTION
We don't really want this constant to be part of this package's public
API. I'm okay with duplicating it in the tests.