### PR TITLE
Remove noop event listener when testing for passive events

### DIFF
--- a/src/canUsePassiveEventListeners.js
+++ b/src/canUsePassiveEventListeners.js
@@ -1,7 +1,7 @@
 import canUseDOM from './canUseDOM';
 
 // Adapted from Modernizr
-// https://github.com/Modernizr/Modernizr/blob/5eea7e2a/feature-detects/dom/passiveeventlisteners.js#L26-L35
+// https://github.com/Modernizr/Modernizr/blob/acb3f0d9/feature-detects/dom/passiveeventlisteners.js#L26-L37
 function testPassiveEventListeners() {
   if (!canUseDOM) {
     return false;
@@ -19,7 +19,9 @@ function testPassiveEventListeners() {
         supportsPassiveOption = true;
       },
     });
-    window.addEventListener('test', null, opts);
+    const noop = () => {};
+    window.addEventListener('testPassiveEventSupport', noop, opts);
+    window.removeEventListener('testPassiveEventSupport', noop, opts);
   } catch (e) {
     // do nothing
   }


### PR DESCRIPTION
I checked in on Modernizr's implementation of this and found that
they've made a small improvement.

This appears to have been done to improve support for EdgeHTML 15:

  https://github.com/Modernizr/Modernizr/pull/2299