### PR TITLE
Convert TargetEventHandlers from class to function

### DIFF
--- a/src/TargetEventHandlers.js
+++ b/src/TargetEventHandlers.js
@@ -7,13 +7,11 @@ function ensureCanMutateNextEventHandlers(eventHandlers) {
   }
 }
 
-export default class TargetEventHandlers {
-  constructor(target) {
-    this.target = target;
-    this.events = {};
-  }
+export default function TargetEventHandlers(target) {
+  this.target = target;
+  this.events = {};
 
-  getEventHandlers(eventName, options) {
+  this.getEventHandlers = (eventName, options) => {
     const key = `${eventName} ${eventOptionsKey(options)}`;
 
     if (!this.events[key]) {
@@ -25,9 +23,9 @@ export default class TargetEventHandlers {
     }
 
     return this.events[key];
-  }
+  };
 
-  handleEvent(eventName, options, event) {
+  this.handleEvent = (eventName, options, event) => {
     const eventHandlers = this.getEventHandlers(eventName, options);
     eventHandlers.handlers = eventHandlers.nextHandlers;
     eventHandlers.handlers.forEach((handler) => {
@@ -39,9 +37,9 @@ export default class TargetEventHandlers {
         handler(event);
       }
     });
-  }
+  };
 
-  add(eventName, listener, options) {
+  this.add = (eventName, listener, options) => {
     // options has already been normalized at this point.
     const eventHandlers = this.getEventHandlers(eventName, options);
 
@@ -92,5 +90,5 @@ export default class TargetEventHandlers {
       }
     };
     return unsubscribe;
-  }
+  };
 }


### PR DESCRIPTION
The code added by Babel to compile this down to ES5 adds about 1.1 KiB
to the built version. We can pretty trivially avoid this for now by
using a function instead of a class. This drops the built filesize from
7.3 KiB to 6.2 KiB, which will be a small win for performance.

I think Babel 7 aims to make some changes that will help us use the
class syntax while avoiding this unnecessary overhead, at which point we
might want to re-evaluate this change. But for now, let's take the easy
bundle size win.