### PR TITLE
Remove deprecated removeEventListener export

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -1,10 +1,9 @@
-import { addEventListener, removeEventListener } from '../src';
+import { addEventListener } from '../src';
 import TargetEventHandlers from '../src/TargetEventHandlers';
 
 class MockTarget {
   constructor() {
     this.addEventListener = jest.fn();
-    this.removeEventListener = jest.fn();
   }
 }
 
@@ -31,34 +30,5 @@ describe('addEventListener()', () => {
     const remove = addEventListener(target, 'scroll', () => {}, { capture: true });
 
     expect(typeof remove).toBe('function');
-  });
-});
-
-describe('removeEventListener()', () => {
-  it('removes event listeners that were previously registered', () => {
-    const target = new MockTarget();
-    const unsubscribe = addEventListener(target, 'scroll', () => {});
-    removeEventListener(unsubscribe);
-
-    expect(target.removeEventListener)
-      .toHaveBeenCalledWith('scroll', jasmine.any(Function), undefined);
-  });
-
-  it('ignores event listeners it does not know about', () => {
-    const target = new MockTarget();
-    addEventListener(target, 'scroll', () => {});
-    removeEventListener(() => {});
-    removeEventListener(() => {});
-
-    expect(target.removeEventListener).toHaveBeenCalledTimes(0);
-  });
-
-  it('normalizes event options', () => {
-    const target = new MockTarget();
-    const unsubscribe = addEventListener(target, 'scroll', () => {}, { capture: true });
-    removeEventListener(unsubscribe);
-
-    expect(target.removeEventListener)
-      .toHaveBeenCalledWith('scroll', jasmine.any(Function), true);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import TargetEventHandlers from './TargetEventHandlers';
 
 const EVENT_HANDLERS_KEY = '__consolidated_events_handlers__';
 
+// eslint-disable-next-line import/prefer-default-export
 export function addEventListener(target, eventName, listener, options) {
   if (!target[EVENT_HANDLERS_KEY]) {
     // eslint-disable-next-line no-param-reassign
@@ -10,9 +11,4 @@ export function addEventListener(target, eventName, listener, options) {
   }
   const normalizedEventOptions = normalizeEventOptions(options);
   return target[EVENT_HANDLERS_KEY].add(eventName, listener, normalizedEventOptions);
-}
-
-// Deprecated
-export function removeEventListener(unsubscribeFn) {
-  unsubscribeFn();
 }


### PR DESCRIPTION
Since the next release of consolidated-events will be semver major, it
is a good time to remove this deprecated named export.

At this time there is now only one named export in this file, which the
linter suggests I should convert to a default export. However, I think
I'd like to minimize the work needed to be done by folks who are
upgrading, so I'm going to leave this as a named export for now.