### PR TITLE
Make TargetEventHandlers a class again but transform it in lose mode

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,8 @@
 {
-  "presets": ["airbnb"]
+  "presets": ["airbnb"],
+  "plugins": [
+    ["transform-es2015-classes", {
+      "loose": true
+    }]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "babel-core": "^6.26.3",
     "babel-jest": "^23.0.1",
+    "babel-plugin-transform-es2015-classes": "^6.24.1",
     "babel-preset-airbnb": "^2.5.1",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,6 +17,9 @@ export default {
     babel({
       babelrc: false,
       presets: [['airbnb', { modules: false }]],
+      plugins: [
+        ['transform-es2015-classes', { loose: true }],
+      ],
     }),
   ],
 };

--- a/src/TargetEventHandlers.js
+++ b/src/TargetEventHandlers.js
@@ -7,11 +7,13 @@ function ensureCanMutateNextEventHandlers(eventHandlers) {
   }
 }
 
-export default function TargetEventHandlers(target) {
-  this.target = target;
-  this.events = {};
+export default class TargetEventHandlers {
+  constructor(target) {
+    this.target = target;
+    this.events = {};
+  }
 
-  this.getEventHandlers = (eventName, options) => {
+  getEventHandlers(eventName, options) {
     const key = `${eventName} ${eventOptionsKey(options)}`;
 
     if (!this.events[key]) {
@@ -23,9 +25,9 @@ export default function TargetEventHandlers(target) {
     }
 
     return this.events[key];
-  };
+  }
 
-  this.handleEvent = (eventName, options, event) => {
+  handleEvent(eventName, options, event) {
     const eventHandlers = this.getEventHandlers(eventName, options);
     eventHandlers.handlers = eventHandlers.nextHandlers;
     eventHandlers.handlers.forEach((handler) => {
@@ -37,9 +39,9 @@ export default function TargetEventHandlers(target) {
         handler(event);
       }
     });
-  };
+  }
 
-  this.add = (eventName, listener, options) => {
+  add(eventName, listener, options) {
     // options has already been normalized at this point.
     const eventHandlers = this.getEventHandlers(eventName, options);
 
@@ -90,5 +92,5 @@ export default function TargetEventHandlers(target) {
       }
     };
     return unsubscribe;
-  };
+  }
 }


### PR DESCRIPTION
This pretty much splits the difference, size wise, between the strict class consolidated-events had before and the current approach. The major advantage however is that with the lose mode it's using the prototype for the methods which saves some memory. With the current code it would keep a copy of every function for every target in memory.

Bundle size (CommonJS) goes up by 744 bytes. (down 599 bytes compared to the version with strict classes). I could probably shave another ~300 bytes off by handwriting the version with prototypes if you'd prefer that.